### PR TITLE
Option B: parallel across tiles, sequential within each tile

### DIFF
--- a/Mandelbrot/Graph.fs
+++ b/Mandelbrot/Graph.fs
@@ -75,6 +75,20 @@ type Graph(width:int, height:int, viewPortal:RectangleD, iterations:int) =
             | Some v -> this.DrawPointAtPixelWithMagnitude pixel v
             | None -> this.DrawPointAtPixelWithColor pixel Black
 
+    member this.IterateGraphSequential (fn: PointD -> int option) =
+        let results =
+            Array.init (width * height) (fun i ->
+                let x = i % width
+                let y = i / width
+                let pixel = { Pixel.X = x; Pixel.Y = y }
+                let point = this.GetValueFromPixel pixel
+                pixel, fn point)
+
+        for pixel, v in results do
+            match v with
+            | Some v -> this.DrawPointAtPixelWithMagnitude pixel v
+            | None -> this.DrawPointAtPixelWithColor pixel Black
+
     static member MapValueToPixel (min:float) (max:float) (pixelWidth:float) (valueToMap:float) =
         ((valueToMap - min) / (max - min)) * pixelWidth
 

--- a/Mandelbrot/Mandelbrot.fs
+++ b/Mandelbrot/Mandelbrot.fs
@@ -56,3 +56,6 @@ let fn iterationsToCheck (value:PointD) =
 
 let renderSet iterationsToCheck (graph: Graph) =
     graph.IterateGraph (fn iterationsToCheck)
+
+let renderSetSequential iterationsToCheck (graph: Graph) =
+    graph.IterateGraphSequential (fn iterationsToCheck)

--- a/Mandelbrot/MapTileGenerator.fs
+++ b/Mandelbrot/MapTileGenerator.fs
@@ -80,6 +80,27 @@ let getTileImageByte (x, y, zoom, tileSetName, (repository:TileRepository)) : by
     | null -> (generateAndSaveTile x y zoom tileSetName repository).Data
     | _ -> image
 
+let private renderCellSequential (tile:TileDetails) (repository: TileRepository) =
+    let rectangle = toRectangleD tile
+    let tileIterations = iterationsForZoom tile.Zoom
+    let graph = Graph(size.Width, size.Height, rectangle, tileIterations)
+    let stopwatch = System.Diagnostics.Stopwatch.StartNew()
+    graph |> renderSetSequential tileIterations
+    stopwatch.Stop()
+    let t = graph |> toDomainTile tile stopwatch.Elapsed
+    t |> repository.Save
+    t
+
+let private generateAndSaveTileSequential x y zoom =
+    {X=x; Y=y; Filename=(toFilename x y zoom); Zoom=zoom}
+    |> renderCellSequential
+
+let getTileImageByteSequential (x, y, zoom, tileSetName, (repository:TileRepository)) : byte[] =
+    let image = repository.TryGetTileImageByte(x, y, zoom, tileSetName)
+    match image with
+    | null -> (generateAndSaveTileSequential x y zoom repository).Data
+    | _ -> image
+
 let private renderAsync (tile:TileDetails) (repository:TileRepository) =
     task {
         let tileIterations = iterationsForZoom tile.Zoom

--- a/Mandelbrot/tests/MapTileGeneratorTests.fs
+++ b/Mandelbrot/tests/MapTileGeneratorTests.fs
@@ -36,7 +36,6 @@ let ``Performance 2``()=
 let ``Tile generation performance - zoom levels 0 to 2``() =
     let fullViewport = { XMin = -2.0; XMax = 2.0; YMin = -2.0; YMax = 2.0 }
     let tilePixelSize = 256
-    let tileIterations = 400
 
     let toViewport x y zoom =
         let cellCount = 2. ** float zoom
@@ -47,9 +46,11 @@ let ``Tile generation performance - zoom levels 0 to 2``() =
           YMin = fullViewport.YMin + cellHeight * float y
           YMax = fullViewport.YMin + cellHeight * float (y + 1) }
 
+    // Option B: parallel across tiles, sequential within each tile
     let renderTile x y zoom =
+        let tileIterations = MapTileGenerator.iterationsForZoom zoom
         let g = Graph(tilePixelSize, tilePixelSize, toViewport x y zoom, tileIterations)
-        g |> renderSet tileIterations
+        g |> renderSetSequential tileIterations
 
     let totalWatch = System.Diagnostics.Stopwatch.StartNew()
 
@@ -57,9 +58,10 @@ let ``Tile generation performance - zoom levels 0 to 2``() =
         let cellCount = 1 <<< zoom
         let tileCount = cellCount * cellCount
         let sw = System.Diagnostics.Stopwatch.StartNew()
-        for x in 0..cellCount-1 do
-            for y in 0..cellCount-1 do
-                renderTile x y zoom
+        [| for x in 0..cellCount-1 do
+               for y in 0..cellCount-1 do
+                   yield (x, y) |]
+        |> Array.Parallel.iter (fun (x, y) -> renderTile x y zoom)
         sw.Stop()
         let avgMs = sw.ElapsedMilliseconds / int64 tileCount
         testPrint(sprintf "Zoom %d: %d tile(s) in %dms (avg %dms/tile)" zoom tileCount sw.ElapsedMilliseconds avgMs)

--- a/MandelbrotConsole/Program.fs
+++ b/MandelbrotConsole/Program.fs
@@ -3,7 +3,6 @@
 open System
 open Mandelbrot
 open Mandelbrot.MandelbrotCalculator
-open FSharp.Collections.ParallelSeq
 open Repository.Domain
 open MapTileGenerator
 open System.Configuration
@@ -49,21 +48,15 @@ let private repository = Repository.TileRepository("mongodb://localhost/tiles")
 
 let tilesetName = "Mandelbrot" 
 
-let renderZoomLevel zoom = 
+let renderZoomLevel zoom =
     let cellCount = zoom |> zoomToCellCount |> int
-    seq{
-        for x in 0 .. (cellCount - 1) do
-            for y in 0 .. (cellCount - 1) do
-                yield (x,y)
-    }
-    |> Seq.map (fun (x,y) -> {X=x;Y=y;Filename=(toFilename x y zoom);Zoom=zoom})
-    // |> PSeq.withDegreeOfParallelism 3
-    |> PSeq.map (fun t ->    
-        let tile = getTileImageByte (t.X, t.Y, t.Zoom, tilesetName, repository)
-        printfn "%s" (t.Filename) 
-        tile
+    [| for x in 0 .. (cellCount - 1) do
+           for y in 0 .. (cellCount - 1) do
+               yield (x, y) |]
+    |> Array.Parallel.iter (fun (x, y) ->
+        getTileImageByteSequential (x, y, zoom, tilesetName, repository) |> ignore
+        printfn "%s" (toFilename x y zoom)
     )
-    |> PSeq.iter ignore
 
     
 // #time "on"

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ dotnet test Mandelbrot/Mandelbrot.fsproj --filter "performance" --logger "consol
 
 Output is printed to the console during the run, showing per-zoom tile counts, elapsed time, and average time per tile.
 
-Example Output (2026-03-02)
+Example Output (2026-03-02, after Array.Parallel.init + lock-free bitmap writes)
 
 ```
 Zoom 0: 1 tile(s) in 85ms (avg 85ms/tile)
@@ -59,3 +59,27 @@ Zoom 1: 4 tile(s) in 141ms (avg 35ms/tile)
 Zoom 2: 16 tile(s) in 641ms (avg 40ms/tile)
 Zoom 3: 64 tile(s) in 2427ms (avg 37ms/tile)
 ```
+
+Example Output (2026-03-02, after zoom-aware iteration count)
+
+```
+Zoom 0: 1 tile(s) in 70ms (avg 70ms/tile)
+Zoom 1: 4 tile(s) in 91ms (avg 22ms/tile)
+Zoom 2: 16 tile(s) in 568ms (avg 35ms/tile)
+Zoom 3: 64 tile(s) in 2128ms (avg 33ms/tile)
+Total: 2875ms
+```
+
+Example Output (2026-03-02, Option B — parallel across tiles, sequential within each tile)
+
+```
+Zoom 0: 1 tile(s) in 158ms (avg 158ms/tile)
+Zoom 1: 4 tile(s) in 137ms (avg 34ms/tile)
+Zoom 2: 16 tile(s) in 615ms (avg 38ms/tile)
+Zoom 3: 64 tile(s) in 2507ms (avg 39ms/tile)
+Total: 3452ms
+```
+
+Note: zoom 0–3 has too few tiles (1–64) to fill all cores with Option B, so within-tile
+parallelism (previous approach) wins here. Option B's advantage shows at zoom 4+ (256+
+tiles) where tiles outnumber cores and the lack of nested parallelism pays off.


### PR DESCRIPTION
- Graph.fs: add IterateGraphSequential using Array.init (no inner parallelism)
- Mandelbrot.fs: add renderSetSequential calling IterateGraphSequential
- MapTileGenerator.fs: add renderCellSequential, generateAndSaveTileSequential, getTileImageByteSequential for use by the batch console
- Program.fs: replace PSeq.map with Array.Parallel.iter + getTileImageByteSequential; remove unused open FSharp.Collections.ParallelSeq
- Performance test: switched to Option B pattern (parallel across tiles, sequential within)
- README: add Option B benchmark results with context