### PR TITLE
Add Docker and Docker Compose support for MandelbrotWeb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+WORKDIR /src
+
+COPY Mandelbrot.sln .
+COPY Mandelbrot/Mandelbrot.fsproj       Mandelbrot/
+COPY Repository/Repository.csproj       Repository/
+COPY MandelbrotWeb/MandelbrotWeb.csproj  MandelbrotWeb/
+COPY MandelbrotConsole/MandelbrotConsole.fsproj MandelbrotConsole/
+
+COPY Mandelbrot/    Mandelbrot/
+COPY Repository/    Repository/
+COPY MandelbrotWeb/ MandelbrotWeb/
+
+RUN dotnet publish MandelbrotWeb/MandelbrotWeb.csproj \
+    -c Release -o /app/publish \
+    /p:ErrorOnDuplicatePublishOutputFiles=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+WORKDIR /app
+COPY --from=build /app/publish .
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "MandelbrotWeb.dll"]

--- a/Mandelbrot/Mandelbrot.fsproj
+++ b/Mandelbrot/Mandelbrot.fsproj
@@ -25,7 +25,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Collections.ParallelSeq" Version="1.2.0" />
-    <PackageReference Include="FsUnit" Version="7.1.1" />
+    <PackageReference Include="FsUnit" Version="7.1.1" PrivateAssets="all" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" PrivateAssets="all" />
     <PackageReference Include="xunit" Version="2.9.3" PrivateAssets="all" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" PrivateAssets="all" />

--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ Various components for viewing a deepzoomable mandelbrot set.
 - MongoDBScripts - Some MongoDB scripts
 - Repository - Module for getting and saving image tiles.
 
+## Docker
+
+Requires Docker and Docker Compose.
+
+```bash
+docker compose up --build
+```
+
+Then open http://localhost:8080
+
+Mongo data is persisted in the `mongo-data` Docker volume between runs.
+
+To build the image without Compose:
+
+```bash
+docker build -t mandelbrot-web .
+docker run -p 8080:8080 -e ConnectionStrings__MongoDb=mongodb://host.docker.internal/tiles mandelbrot-web
+```
+
 ## To run web pages
 
 ### Linux / OSX

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  web:
+    build: .
+    ports:
+      - "8080:8080"
+    environment:
+      - ConnectionStrings__MongoDb=mongodb://mongo/tiles
+    depends_on:
+      - mongo
+
+  mongo:
+    image: mongo:8
+    volumes:
+      - mongo-data:/data/db
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
Multi-stage Dockerfile builds MandelbrotWeb in a .NET SDK container and produces a lean ASP.NET runtime image. docker-compose.yml wires the web service to a mongo:8 container with a persistent volume.

Mark FsUnit as PrivateAssets="all" so it doesn't leak into the publish output (fixes NETSDK1152 duplicate-file error during image build).

Add Docker build/run instructions to README.md.